### PR TITLE
SC-159460 type checking in eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,10 +2,13 @@ module.exports = {
   root: true,
   ignorePatterns: ["**/*.js", ".dist/**/*", "build/**/*", "dist/**/*"],
   parser: "@typescript-eslint/parser",
+  parserOptions: {
+    project: "./tsconfig.json",
+  },
   plugins: ["@typescript-eslint"],
   extends: [
     "eslint:recommended",
-    "plugin:@typescript-eslint/strict-type-checked",
+    "plugin:@typescript-eslint/recommended-type-checked",
     "plugin:react-hooks/recommended",
     "prettier",
   ],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
   plugins: ["@typescript-eslint"],
   extends: [
     "eslint:recommended",
-    "plugin:@typescript-eslint/recommended",
+    "plugin:@typescript-eslint/strict-type-checked",
     "plugin:react-hooks/recommended",
     "prettier",
   ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4851,7 +4851,7 @@ snapshots:
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@5.5.0)
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.1
@@ -5382,7 +5382,7 @@ snapshots:
   '@humanwhocodes/config-array@0.11.14':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@5.5.0)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -5970,7 +5970,7 @@ snapshots:
       '@typescript-eslint/type-utils': 6.20.0(eslint@8.56.0)(typescript@4.9.5)
       '@typescript-eslint/utils': 6.20.0(eslint@8.56.0)(typescript@4.9.5)
       '@typescript-eslint/visitor-keys': 6.20.0
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@5.5.0)
       eslint: 8.56.0
       graphemer: 1.4.0
       ignore: 5.3.1
@@ -5988,7 +5988,7 @@ snapshots:
       '@typescript-eslint/types': 6.20.0
       '@typescript-eslint/typescript-estree': 6.20.0(typescript@4.9.5)
       '@typescript-eslint/visitor-keys': 6.20.0
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@5.5.0)
       eslint: 8.56.0
     optionalDependencies:
       typescript: 4.9.5
@@ -6004,7 +6004,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 6.20.0(typescript@4.9.5)
       '@typescript-eslint/utils': 6.20.0(eslint@8.56.0)(typescript@4.9.5)
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@5.5.0)
       eslint: 8.56.0
       ts-api-utils: 1.3.0(typescript@4.9.5)
     optionalDependencies:
@@ -6018,7 +6018,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 6.20.0
       '@typescript-eslint/visitor-keys': 6.20.0
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@5.5.0)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
@@ -6583,10 +6583,6 @@ snapshots:
 
   debounce@1.2.1: {}
 
-  debug@4.3.5:
-    dependencies:
-      ms: 2.1.2
-
   debug@4.3.5(supports-color@5.5.0):
     dependencies:
       ms: 2.1.2
@@ -6789,7 +6785,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@5.5.0)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4851,7 +4851,7 @@ snapshots:
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.5(supports-color@5.5.0)
+      debug: 4.3.5
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.1
@@ -5382,7 +5382,7 @@ snapshots:
   '@humanwhocodes/config-array@0.11.14':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.3.5(supports-color@5.5.0)
+      debug: 4.3.5
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -5970,7 +5970,7 @@ snapshots:
       '@typescript-eslint/type-utils': 6.20.0(eslint@8.56.0)(typescript@4.9.5)
       '@typescript-eslint/utils': 6.20.0(eslint@8.56.0)(typescript@4.9.5)
       '@typescript-eslint/visitor-keys': 6.20.0
-      debug: 4.3.5(supports-color@5.5.0)
+      debug: 4.3.5
       eslint: 8.56.0
       graphemer: 1.4.0
       ignore: 5.3.1
@@ -5988,7 +5988,7 @@ snapshots:
       '@typescript-eslint/types': 6.20.0
       '@typescript-eslint/typescript-estree': 6.20.0(typescript@4.9.5)
       '@typescript-eslint/visitor-keys': 6.20.0
-      debug: 4.3.5(supports-color@5.5.0)
+      debug: 4.3.5
       eslint: 8.56.0
     optionalDependencies:
       typescript: 4.9.5
@@ -6004,7 +6004,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 6.20.0(typescript@4.9.5)
       '@typescript-eslint/utils': 6.20.0(eslint@8.56.0)(typescript@4.9.5)
-      debug: 4.3.5(supports-color@5.5.0)
+      debug: 4.3.5
       eslint: 8.56.0
       ts-api-utils: 1.3.0(typescript@4.9.5)
     optionalDependencies:
@@ -6018,7 +6018,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 6.20.0
       '@typescript-eslint/visitor-keys': 6.20.0
-      debug: 4.3.5(supports-color@5.5.0)
+      debug: 4.3.5
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
@@ -6583,6 +6583,10 @@ snapshots:
 
   debounce@1.2.1: {}
 
+  debug@4.3.5:
+    dependencies:
+      ms: 2.1.2
+
   debug@4.3.5(supports-color@5.5.0):
     dependencies:
       ms: 2.1.2
@@ -6785,7 +6789,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.5(supports-color@5.5.0)
+      debug: 4.3.5
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2


### PR DESCRIPTION
source: https://app.shortcut.com/deskpro/story/159460/stricter-es-lint-rules?vc_group_by=day&ct_workflow=all&cf_workflow=500068040

This will reduce the likelihood of bugs reaching production as well as ensure code is efficient (e.g. not doing checks for things that don't happen) which will help run time performance and the developer experience.

This is also public facing so we should do our best to show our best face.