### PR TITLE
[Bug] (SC-204212) Improve site name fallback handling in `Filters` component

### DIFF
--- a/src/components/LinkDevice/blocks/Filters.tsx
+++ b/src/components/LinkDevice/blocks/Filters.tsx
@@ -1,9 +1,7 @@
-import { useMemo } from "react";
 import { Search, Select } from "@deskpro/app-sdk";
-import { getOptions } from "@/utils";
 import { Label } from "@/components/common";
 import type { FC } from "react";
-import type { Maybe,Option } from "@/types";
+import type { Maybe, Option } from "@/types";
 import type { Site } from "@/services/lansweeper/types";
 
 type Props = {
@@ -15,7 +13,12 @@ type Props = {
 };
 
 const Filters: FC<Props> = ({ sites, siteId, isFetching, onChangeSearchQuery, onChangeSite }) => {
-  const options = useMemo(() => getOptions(sites, "brandingName"), [sites]) as Array<Option>;
+  const siteOptions: Option[] = sites.map((site) => ({
+    value: site.id,
+    label: site.brandingName || site.name || `Unnamed Site (${site.id})`,
+    key: site.id,
+    type: "value",
+  }))
 
   return (
     <>
@@ -26,7 +29,7 @@ const Filters: FC<Props> = ({ sites, siteId, isFetching, onChangeSearchQuery, on
       <Label label="Site" required>
         <Select
           value={siteId}
-          options={options}
+          options={siteOptions}
           onChange={onChangeSite as () => void}
         />
       </Label>

--- a/src/components/LinkDevice/blocks/__tests__/Filters.test.tsx
+++ b/src/components/LinkDevice/blocks/__tests__/Filters.test.tsx
@@ -1,0 +1,36 @@
+import { lightTheme } from "@deskpro/deskpro-ui";
+import { render } from "@testing-library/react";
+import { ThemeProvider } from "styled-components";
+import { Filters } from "../Filters";
+
+function renderComponent(site: { id: string; name?: string; brandingName?: string }) {
+  return render(
+    <ThemeProvider theme={lightTheme}>
+      <Filters
+        isFetching={false}
+        sites={[
+          site,
+        ]}
+        siteId="dp-97"
+        onChangeSearchQuery={jest.fn()}
+        onChangeSite={jest.fn()}
+      />
+    </ThemeProvider>
+  )
+}
+
+
+describe("Filters", () => {
+  it.each([
+    [{ id: "dp-97" }, "Unnamed Site (dp-97)"],
+    [{ id: "dp-97", name: "Deskpro Site" }, "Deskpro Site"],
+    [
+      { id: "dp-97", name: "Deskpro Site", brandingName: "Deskpro Site (Branding)" },
+      "Deskpro Site (Branding)",
+    ],
+  ])("correctly handles site name fallbacks", (site, target) => {
+    const { getByText } = renderComponent(site)
+
+    expect(getByText(target)).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Description
This PR replaces site ID with site name in Filters component and add tests for site name fallbacks.

## Evidence
<img  title="Site select in Deskpro" width="126" height="155" alt="Site select in Deskpro" src="https://github.com/user-attachments/assets/52d4ae0a-7182-4607-b644-25fda7f39f0f" />

<img title="Site select in Lansweeper" width="130" height="96" alt="Site select in Lansweeper" src="https://github.com/user-attachments/assets/f81cfc26-b8f2-4bbf-a989-5ad712694e09" />

## Summary by Sourcery

Update the LinkDevice Filters component to use human-friendly site name fallbacks and add coverage for the new behavior.

Bug Fixes:
- Ensure the Filters site selector displays a meaningful label using branding name, then name, then an 'Unnamed Site (id)' fallback instead of relying on site ID alone.

Tests:
- Add unit tests verifying the Filters component’s site label fallback order for branding name, name, and unnamed sites.